### PR TITLE
Fix typographical error(s)

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -107,7 +107,7 @@ This will create a local test server with watch / compile action.
 
 ## FAQ
 
-Q: Is Platonic ready for commerical use?
+Q: Is Platonic ready for commercial use?
 
 A: With the current browser support list being very limited at this moment of time I recommend only using Platonic for experimental CSS3D projects. 
 


### PR DESCRIPTION
@davidpaulrosser, I've corrected a typographical error in the documentation of the [stylus-platonic](https://github.com/davidpaulrosser/stylus-platonic) project. Specifically, I've changed commerical to commercial. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
